### PR TITLE
enforced client component setting w/ use client

### DIFF
--- a/src/app/investigations/page.tsx
+++ b/src/app/investigations/page.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { handleSubmit } from "./actions"
 
 export default function InvestigationPage() {


### PR DESCRIPTION
I learned that my investigation page was not automatically being set as a client component. Added 'use client' to make sure the component is a client component and tested that it works that way
